### PR TITLE
Add support for providing extra `copts` to the `bison` build.

### DIFF
--- a/bison/bison.bzl
+++ b/bison/bison.bzl
@@ -25,13 +25,14 @@ bison_repository = _bison_repository
 def bison_toolchain(ctx):
     return ctx.toolchains[BISON_TOOLCHAIN_TYPE].bison_toolchain
 
-def bison_register_toolchains(version = DEFAULT_VERSION):
+def bison_register_toolchains(version = DEFAULT_VERSION, extra_copts = []):
     check_version(version)
     repo_name = "bison_v{}".format(version)
     if repo_name not in native.existing_rules().keys():
         bison_repository(
             name = repo_name,
             version = version,
+            extra_copts = extra_copts,
         )
     native.register_toolchains("@rules_bison//bison/toolchains:v{}".format(version))
 

--- a/bison/internal/gnulib/gnulib.BUILD
+++ b/bison/internal/gnulib/gnulib.BUILD
@@ -181,7 +181,7 @@ cc_library(
         "//conditions:default": _GNULIB_LINUX_SRCS,
     }),
     hdrs = _GNULIB_HDRS,
-    copts = _COPTS + ["-DHAVE_CONFIG_H"],
+    copts = _COPTS + ["-DHAVE_CONFIG_H"] + {GNULIB_EXTRA_COPTS},
     includes = ["lib"],
     textual_hdrs = [
         "lib/printf-frexp.c",

--- a/bison/internal/gnulib/gnulib.bzl
+++ b/bison/internal/gnulib/gnulib.bzl
@@ -63,14 +63,16 @@ _CONFIGMAKE_H = """
 #define PKGDATADIR "{WORKSPACE_ROOT}/data"
 """
 
-def gnulib_overlay(ctx, bison_version):
+def gnulib_overlay(ctx, bison_version, extra_copts = []):
     ctx.download_and_extract(
         url = _GNULIB_URLS,
         sha256 = _GNULIB_SHA256,
         output = "gnulib",
         stripPrefix = "gnulib-" + _GNULIB_VERSION,
     )
-    ctx.symlink(ctx.attr._gnulib_build, "gnulib/BUILD.bazel")
+    ctx.template("gnulib/BUILD.bazel", ctx.attr._gnulib_build, substitutions = {
+        "{GNULIB_EXTRA_COPTS}": str(extra_copts),
+    }, executable = False)
 
     config_header = _CONFIG_HEADER.format(
         BISON_VERSION = bison_version,

--- a/bison/internal/repository.bzl
+++ b/bison/internal/repository.bzl
@@ -59,6 +59,7 @@ BISON_LIB_SRCS = glob(["bison-lib/*"])
 cc_library(
     name = "bison_lib",
     srcs = BISON_SRC_SRCS + BISON_LIB_SRCS,
+    copts = {EXTRA_COPTS},
     includes = [".", "bison-lib"],
     strip_include_prefix = "bison-lib",
     textual_hdrs = BISON_SCANNER_SRCS,
@@ -88,6 +89,8 @@ cc_binary(
 
 def _bison_repository(ctx):
     version = ctx.attr.version
+    extra_copts = ctx.attr.extra_copts
+
     _check_version(version)
     source = _VERSION_URLS[version]
 
@@ -97,10 +100,10 @@ def _bison_repository(ctx):
         stripPrefix = "bison-{}".format(version),
     )
 
-    _gnulib_overlay(ctx, bison_version = version)
+    _gnulib_overlay(ctx, bison_version = version, extra_copts = extra_copts)
 
     ctx.file("WORKSPACE", "workspace(name = {name})\n".format(name = repr(ctx.name)))
-    ctx.file("BUILD.bazel", _BISON_BUILD)
+    ctx.file("BUILD.bazel", _BISON_BUILD.format(EXTRA_COPTS = extra_copts))
     ctx.file("bin/BUILD.bazel", _BISON_BIN_BUILD)
 
     # A couple headers in lib/ get included with angle brackets. To avoid
@@ -113,6 +116,7 @@ bison_repository = repository_rule(
     _bison_repository,
     attrs = {
         "version": attr.string(mandatory = True),
+        "extra_copts": attr.string_list(),
         "_gnulib_build": attr.label(
             default = "@rules_bison//bison/internal:gnulib/gnulib.BUILD",
             allow_single_file = True,


### PR DESCRIPTION
This is important for users with toolchains that will produce
significant warnings when building. We could try to guess at what flags
would silence these warnings (the same way the current code does for
MSVC), but on non-Windows platforms there are multiple different
compilers and compiler versions all with different warning flags.

Instead, simply provide a way for the caller to thread their own flags
through. They can in turn build whatever compiler detection logic is
desired.

It would be possible to just turn off warnings in a blanket way by
passing the flag `-w` on all non-Windows builds. On one hand, this is
a bit simpler. However, it seems rather inelegant and doesn't seem very
sustainable. As an example of where I expect this will break down is for
folks using Clang on Windows.

See the related PR for M4: https://github.com/jmillikin/rules_m4/pull/7