### PR TITLE
Update Bazel / Buildifier version in presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,8 +1,7 @@
 ---
 validate_config: 1
-bazel: 1.0.0
 buildifier:
-  version: 0.29.0
+  version: 4.0.1
   warnings: "-module-docstring,-function-docstring,-bzl-visibility"
 tasks:
   ubuntu_1804_gcc:


### PR DESCRIPTION
Testing with Bazel 1.0.0 is not supported on Bazel CI anymore and the Buildifier version 0.29.0 is also vastly outdated.