### PR TITLE
Update to Bison 3.8.2

### DIFF
--- a/bison/internal/versions.bzl
+++ b/bison/internal/versions.bzl
@@ -22,9 +22,14 @@ _MIRRORS = [
 def _urls(filename):
     return [m + filename for m in _MIRRORS]
 
-DEFAULT_VERSION = "3.3.2"
+DEFAULT_VERSION = "3.8.2"
 
 VERSION_URLS = {
+    "3.8.2": {
+        "urls":  _urls("bison-3.8.2.tar.xz"),
+        "sha256": "9bba0214ccf7f1079c5d59210045227bcf619519840ebfa80cd3849cff5a5bf2",
+        "copyright_year": "2021", 
+    },
     "3.3.2": {
         "urls": _urls("bison-3.3.2.tar.xz"),
         "sha256": "039ee45b61d95e5003e7e8376f9080001b4066ff357bde271b7faace53b9d804",


### PR DESCRIPTION
Verified SHA1 matched https://lists.libreplanet.org/archive/html/bug-bison/2021-09/msg00056.html

This is much more complicated than just building a new Bison because the Bazel build process fetches a tarball of an old gnulib, which does not match the included one and is too old for this new Bison.