### PR TITLE
Flipped `incompatible_disallow_empty_glob`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+# Bazel configuration flags
+
+common --incompatible_disallow_empty_glob=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Git ignore patterns
+
+/bazel-*

--- a/bison/internal/gnulib/gnulib.BUILD
+++ b/bison/internal/gnulib/gnulib.BUILD
@@ -118,7 +118,7 @@ _GNULIB_SRCS = glob([
     "lib/xmalloc.c",
     "lib/xmemdup0.c",
     "lib/xstrndup.c",
-])
+], allow_empty = True)
 
 _GNULIB_DARWIN_SRCS = []
 

--- a/bison/rules/bison_java_library.bzl
+++ b/bison/rules/bison_java_library.bzl
@@ -95,5 +95,7 @@ java_binary(
         JavaInfo,
         OutputGroupInfo,
     ],
-    toolchains = BISON_ACTION_TOOLCHAINS,
+    toolchains = BISON_ACTION_TOOLCHAINS + [
+        "@bazel_tools//tools/jdk:toolchain_type",
+    ],
 )


### PR DESCRIPTION
For this change I assumed there was a reason these sources were not passed directly vs being in a glob and opted to simply allow files to be missing.