### PR TITLE
Fixed incompatibility issues failing BCR dependents

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,10 @@ module(
 )
 
 bazel_dep(name = "rules_m4", version = "0.2.3")
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_java", version = "8.11.0")
 
+bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 bazel_dep(
     name = "googletest",
     version = "1.12.1",

--- a/bison/internal/BUILD
+++ b/bison/internal/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 filegroup(
     name = "bzl_srcs",
     srcs = glob([

--- a/bison/internal/bison_action.bzl
+++ b/bison/internal/bison_action.bzl
@@ -54,7 +54,7 @@ Bison documentation regarding the `%skeleton` directive for more details.
     "_m4_deny_shell": attr.label(
         executable = True,
         default = "//bison/internal:m4_deny_shell",
-        cfg = "host",
+        cfg = "exec",
     ),
 }
 

--- a/bison/internal/toolchain_info.bzl
+++ b/bison/internal/toolchain_info.bzl
@@ -64,7 +64,7 @@ bison_toolchain_info = rule(
         "bison_tool": attr.label(
             mandatory = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "bison_env": attr.string_dict(),
     },

--- a/bison/rules/bison_cc_library.bzl
+++ b/bison/rules/bison_cc_library.bzl
@@ -16,6 +16,8 @@
 
 """Definition of the `bison_cc_library` build rule."""
 
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
     "//bison/internal:bison_action.bzl",
     "BISON_ACTION_TOOLCHAINS",

--- a/bison/rules/bison_java_library.bzl
+++ b/bison/rules/bison_java_library.bzl
@@ -16,6 +16,8 @@
 
 """Definition of the `bison_java_library` build rule."""
 
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load(
     "//bison/internal:bison_action.bzl",
     "BISON_ACTION_TOOLCHAINS",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,3 +1,8 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load(
     "//bison:bison.bzl",
     "bison_cc_library",

--- a/tools/stardoc/BUILD
+++ b/tools/stardoc/BUILD
@@ -1,11 +1,30 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+
+# TODO: Required due to https://github.com/bazelbuild/rules_cc/issues/279
+bzl_library(
+    name = "rules_cc_bzl_lib",
+    srcs = ["@rules_cc//cc:bzl_srcs"],
+    deps = [
+        "@rules_cc//cc/common",
+    ],
+)
+
+bzl_library(
+    name = "bzl_lib",
+    srcs = ["//bison:bzl_srcs"],
+    deps = [
+        ":rules_cc_bzl_lib",
+        "@rules_java//java:rules",
+    ],
+)
 
 stardoc(
     name = "bison_md",
     out = "bison.md",
     header_template = ":header.vm",
     input = "//bison:bison_bzl",
-    deps = ["//bison:bzl_srcs"],
+    deps = [":bzl_lib"],
 )
 
 stardoc(
@@ -13,7 +32,7 @@ stardoc(
     out = "bison_repository_ext.md",
     header_template = ":empty.vm",
     input = "//bison/extensions:bison_repository_ext_bzl",
-    deps = ["//bison:bzl_srcs"],
+    deps = [":bzl_lib"],
 )
 
 # https://github.com/bazelbuild/stardoc/issues/78


### PR DESCRIPTION
This accounts for [incompatible_disable_starlark_host_transitions](https://github.com/bazelbuild/bazel/issues/17032) and [incompatible_autoload_externally](https://github.com/bazelbuild/bazel/issues/23043).