### PR TITLE
add 3.8.2 bison to list of tools

### DIFF
--- a/bison/internal/versions.bzl
+++ b/bison/internal/versions.bzl
@@ -27,6 +27,11 @@ def _urls(filename):
 DEFAULT_VERSION = "3.3.2"
 
 VERSION_URLS = {
+    "3.8.2": {
+        "urls": _urls("bison-3.8.2.tar.xz"),
+        "sha256": "9bba0214ccf7f1079c5d59210045227bcf619519840ebfa80cd3849cff5a5bf2",
+        "copyright_year": "2021",
+    },
     "3.3.2": {
         "urls": _urls("bison-3.3.2.tar.xz"),
         "sha256": "039ee45b61d95e5003e7e8376f9080001b4066ff357bde271b7faace53b9d804",

--- a/bison/rules/bison_repository.bzl
+++ b/bison/rules/bison_repository.bzl
@@ -47,7 +47,7 @@ BISON_SCANNER_SRCS = glob(
 )
 
 BISON_SRC_SRCS = glob(
-    ["src/*.c", "src/*.h"],
+    ["src/*.c", "src/*.h", "lib/*.h"],
     exclude = BISON_SCANNER_SRCS,
 )
 


### PR DESCRIPTION
The last version added as 3.3.2 and the latest (2021) is 3.8.2.

 Can we update it?